### PR TITLE
feat: add deep linking (Universal Links, App Links, Smart Banner)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,12 @@ const nextConfig: NextConfig = {
   },
   headers: async () => [
     {
+      source: "/.well-known/apple-app-site-association",
+      headers: [
+        { key: "Content-Type", value: "application/json" },
+      ],
+    },
+    {
       source: "/(.*)",
       headers: [
         { key: "X-Frame-Options", value: "DENY" },

--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,23 @@
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["WDB2HN7DW7.com.malinmw.wellingtonapp"],
+        "components": [
+          { "/": "/post/*", "comment": "Post pages" },
+          { "/": "/place/*", "comment": "Place pages" },
+          { "/": "/event/*", "comment": "Event pages" },
+          { "/": "/user/*", "comment": "User pages" },
+          { "/": "/trail/*", "comment": "Trail pages" },
+          { "/": "/guide/*", "comment": "Guide pages" },
+          { "/": "/privacy", "exclude": true },
+          { "/": "/support", "exclude": true },
+          { "/": "/admin/*", "exclude": true }
+        ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": ["WDB2HN7DW7.com.malinmw.wellingtonapp"]
+  }
+}

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.welly.app",
+      "sha256_cert_fingerprints": []
+    }
+  }
+]

--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { mapEvent, mapPlace } from "@/lib/mappers";
-import { SITE_URL, getEventDeepLink, CATEGORY_LABELS } from "@/lib/constants";
+import { SITE_URL, APP_STORE_ID, getEventDeepLink, CATEGORY_LABELS } from "@/lib/constants";
 import { OpenInAppButton } from "@/components/OpenInAppButton";
 import { AppStoreBanner } from "@/components/AppStoreBanner";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -66,6 +66,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description,
       images: [imageUrl],
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_ID}, app-argument=${SITE_URL}/event/${eventId}`,
     },
   };
 }

--- a/src/app/guide/[guideId]/page.tsx
+++ b/src/app/guide/[guideId]/page.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/lib/supabase";
 import { mapGuide, mapGuidePlace, mapProfile } from "@/lib/mappers";
 import {
   SITE_URL,
+  APP_STORE_ID,
   getGuideDeepLink,
   CATEGORY_LABELS,
 } from "@/lib/constants";
@@ -76,6 +77,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description,
       images: [imageUrl],
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_ID}, app-argument=${SITE_URL}/guide/${guideId}`,
     },
   };
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
 import "./globals.css";
-import { SITE_URL, APP_NAME } from "@/lib/constants";
+import { SITE_URL, APP_NAME, APP_STORE_ID } from "@/lib/constants";
 
 const plusJakarta = Plus_Jakarta_Sans({
   variable: "--font-plus-jakarta",
@@ -24,6 +24,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
+  },
+  other: {
+    "apple-itunes-app": `app-id=${APP_STORE_ID}`,
   },
 };
 

--- a/src/app/place/[placeId]/page.tsx
+++ b/src/app/place/[placeId]/page.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/lib/supabase";
 import { mapPlace, mapPost, mapProfile } from "@/lib/mappers";
 import {
   SITE_URL,
+  APP_STORE_ID,
   getPlaceDeepLink,
   CATEGORY_LABELS,
 } from "@/lib/constants";
@@ -75,6 +76,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description,
       images: [imageUrl],
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_ID}, app-argument=${SITE_URL}/place/${placeId}`,
     },
   };
 }

--- a/src/app/post/[postId]/page.tsx
+++ b/src/app/post/[postId]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { mapPost, mapPlace, mapProfile } from "@/lib/mappers";
-import { SITE_URL, getPostDeepLink } from "@/lib/constants";
+import { SITE_URL, APP_STORE_ID, getPostDeepLink } from "@/lib/constants";
 import { OpenInAppButton } from "@/components/OpenInAppButton";
 import { AppStoreBanner } from "@/components/AppStoreBanner";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -75,6 +75,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description,
       images: [imageUrl],
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_ID}, app-argument=${SITE_URL}/post/${postId}`,
     },
   };
 }

--- a/src/app/trail/[trailId]/page.tsx
+++ b/src/app/trail/[trailId]/page.tsx
@@ -4,6 +4,7 @@ import { supabase } from "@/lib/supabase";
 import { mapTrail, mapPlace } from "@/lib/mappers";
 import {
   SITE_URL,
+  APP_STORE_ID,
   getTrailDeepLink,
   DIFFICULTY_LABELS,
   DIFFICULTY_COLORS,
@@ -59,6 +60,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description,
       images: [ogUrl],
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_ID}, app-argument=${SITE_URL}/trail/${trailId}`,
     },
   };
 }

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import { notFound } from "next/navigation";
 import { supabase } from "@/lib/supabase";
 import { mapProfile, mapPost } from "@/lib/mappers";
-import { SITE_URL, getUserDeepLink } from "@/lib/constants";
+import { SITE_URL, APP_STORE_ID, getUserDeepLink } from "@/lib/constants";
 import { OpenInAppButton } from "@/components/OpenInAppButton";
 import { AppStoreBanner } from "@/components/AppStoreBanner";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -73,6 +73,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       title,
       description,
       images: [imageUrl],
+    },
+    other: {
+      "apple-itunes-app": `app-id=${APP_STORE_ID}, app-argument=${SITE_URL}/user/${userId}`,
     },
   };
 }

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -8,7 +8,19 @@ import {
   getTrailDeepLink,
   getGuideDeepLink,
   DEEP_LINK_SCHEME,
+  APP_STORE_ID,
+  APP_STORE_URL,
 } from "../constants";
+
+describe("APP_STORE_ID", () => {
+  it("equals the known App Store ID", () => {
+    expect(APP_STORE_ID).toBe("6744381547");
+  });
+
+  it("is included in APP_STORE_URL", () => {
+    expect(APP_STORE_URL).toContain(APP_STORE_ID);
+  });
+});
 
 describe("getDeepLink", () => {
   it("prefixes path with deep link scheme and slash", () => {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -5,7 +5,8 @@ export const DEEP_LINK_SCHEME = "wellington://";
 
 export const APP_NAME = "Welly";
 
-export const APP_STORE_URL = "https://apps.apple.com/app/welly/id0000000000"; // TODO: replace with real ID
+export const APP_STORE_ID = "6744381547";
+export const APP_STORE_URL = `https://apps.apple.com/app/welly/id${APP_STORE_ID}`;
 export const PLAY_STORE_URL =
   "https://play.google.com/store/apps/details?id=com.welly.app"; // TODO: replace with real ID
 


### PR DESCRIPTION
## Summary

- **Apple App Site Association** (`/.well-known/apple-app-site-association`) — enables iOS Universal Links for all content paths (`/post/*`, `/place/*`, `/event/*`, `/user/*`, `/trail/*`, `/guide/*`) with exclusions for `/privacy`, `/support`, `/admin/*`
- **Android Asset Links** (`/.well-known/assetlinks.json`) — placeholder for future Android App Links (`com.welly.app`)
- **Safari Smart App Banner** — global `apple-itunes-app` meta tag (app-id `6744381547`) in root layout, plus per-page `app-argument` on all 6 content pages so the banner deep links to the correct content
- **Constants update** — added `APP_STORE_ID`, derived `APP_STORE_URL` from it (replaces placeholder)
- **Content-Type header** for AASA file in `next.config.ts` (must be `application/json`)
- **Tests** for `APP_STORE_ID` and `APP_STORE_URL`

## Test plan

- [x] `npm run build` — no build errors
- [x] `npm test` — all 38 tests pass
- [ ] After deploy: `curl -I https://welly.nz/.well-known/apple-app-site-association` returns `Content-Type: application/json`
- [ ] After deploy: validate AASA at https://search.developer.apple.com/appsearch-validation-tool/
- [ ] Verify Smart Banner appears in iOS Safari on content pages with correct app-argument

> **Note:** The iOS app must have the Associated Domains entitlement with `applinks:welly.nz` for Universal Links to work end-to-end (app-side config, not part of this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)