### PR TITLE
Infinite scroll, site redesign, and AI event descriptions

### DIFF
--- a/src/app/event/[eventId]/page.tsx
+++ b/src/app/event/[eventId]/page.tsx
@@ -43,9 +43,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     day: "numeric",
     month: "long",
   });
+  const eventDescription = event.aiDescription ?? event.description;
   const description = place
-    ? `${formattedDate} at ${place.name} - ${event.description.slice(0, 150)}`
-    : `${formattedDate} - ${event.description.slice(0, 150)}`;
+    ? `${formattedDate} at ${place.name} - ${eventDescription.slice(0, 150)}`
+    : `${formattedDate} - ${eventDescription.slice(0, 150)}`;
 
   const imageUrl = event.imageUrl
     ? event.imageUrl
@@ -164,7 +165,7 @@ export default async function EventPage({ params }: Props) {
 
         {/* Description */}
         <p className="text-sm leading-relaxed text-gray-600 whitespace-pre-line dark:text-gray-300">
-          {event.description}
+          {event.aiDescription ?? event.description}
         </p>
 
         {/* Ticket link */}

--- a/src/lib/mappers.ts
+++ b/src/lib/mappers.ts
@@ -76,6 +76,7 @@ export function mapEvent(row: {
   ticket_url: string | null;
   price: number | null;
   ai_score?: number | null;
+  ai_description?: string | null;
 }): Event {
   return {
     id: row.id,
@@ -90,6 +91,7 @@ export function mapEvent(row: {
     ticketUrl: row.ticket_url ?? undefined,
     price: row.price,
     aiScore: row.ai_score ?? undefined,
+    aiDescription: row.ai_description ?? undefined,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface Event {
   ticketUrl?: string;
   price?: number | null;
   aiScore?: number | null;
+  aiDescription?: string;
 }
 
 export interface User {


### PR DESCRIPTION
## Summary
- Add infinite scroll to browse pages (feed, events, guides) with API routes and `useInfiniteScroll` hook
- Redesign post detail page with media gallery carousel and improved layout
- Redesign landing page and add shared Nav/Footer components
- Add category filter support for events browse page
- Add reusable card components (PostCard, EventCard, GuideCard, PlaceCard)
- Use `ai_description` for events when available, falling back to regular description
- Fix event price formatting (two decimal places) and carousel control z-index

## Test plan
- [ ] Verify infinite scroll loads more items on feed, events, and guides pages
- [ ] Verify category filtering works on events page
- [ ] Verify post detail media gallery carousel works with multiple images
- [ ] Verify events display `ai_description` when available, regular description otherwise
- [ ] Verify OG metadata uses AI description for events
- [ ] Verify event prices display with two decimal places
- [ ] Check responsive layout on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)